### PR TITLE
Add setup file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,27 @@
+from setuptools import setup, find_namespace_packages
+
+requirements = [
+    "numpy",
+    "pandas",
+    "vtkplotter",
+    "vtk",
+    "jupyter",
+    "allensdk",
+    "k3d",
+    "tqdm",
+]
+
+setup(
+    name="BrainRender",
+    version="0.1.0",
+    description="Python scripts to use Allen Brain Map data for analysis "
+                "and rendering",
+    install_requires=requirements,
+    python_requires=">=3.6",
+    packages=find_namespace_packages(exclude=(
+        "Installation", "Meshes", "Metadata", "Screenshots")),
+    include_package_data=True,
+    url="https://github.com/BrancoLab/BrainRender",
+    author="Federico Claudi",
+    zip_safe=False,
+)


### PR DESCRIPTION
Tested on Linux (Ubuntu 18.04) and Windows (10 Enterprise LTSC) with Python 3.6.9.

Installation seems to work fine via:
`conda create --name brainrender python=3.6`
`conda activate brainrender`
`pip install BrainRender`

If merged, BrainRender should be installable with:
`pip install git+https://github.com/BrancoLab/BrainRender`