### PR TITLE
Add scene.add_image  method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,5 @@
 *.ckpt
-*.ckpt
 *.vscode
-*.mp4
 *.mp4
 *.tdms
 *.jpg
@@ -32,4 +30,118 @@ Users/
 
 workspace.py
 secrets
+
+# Custom config files
+*.conf.custom
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+doc/build/
+
+# pydocmd
+_build/
+mkdocs.yml
+
+# PyBuilder
+target/
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+
+.idea/
+
+*.~lock.*
+
 

--- a/BrainRender/Utils/ABA/connectome.py
+++ b/BrainRender/Utils/ABA/connectome.py
@@ -22,10 +22,10 @@ class ABA(Paths):
     # useful vars for analysis    
     excluded_regions = ["fiber tracts"]
 
-    def __init__(self, projection_metric = "projection_energy", path_file=None):
+    def __init__(self, projection_metric = "projection_energy", paths_file=None):
         """ path_file {[str]} -- [Path to a YAML file specifying paths to data folders, to replace default paths] (default: {None}) """
 
-        Paths.__init__(self)
+        Paths.__init__(self, paths_file=paths_file)
 
         self.projection_metric = projection_metric
 

--- a/BrainRender/Utils/image.py
+++ b/BrainRender/Utils/image.py
@@ -1,0 +1,74 @@
+from skimage import measure
+import numpy as np
+from brainio import brainio
+
+
+def marching_cubes_to_obj(marching_cubes_out, output_file):
+    """[Saves the output of skimage.measure.marching_cubes as an .obj file]
+
+    Arguments:
+        marching_cubes_out {[tuple]} -- [skimage.measure.marching_cubes output]
+        output_file {[str]} -- [File to write to]
+    """
+
+    verts, faces, normals, _ = marching_cubes_out
+    with open(output_file, 'w') as f:
+        for item in verts:\
+            f.write(f"v {item[0]} {item[1]} {item[2]}\n")
+        for item in normals:
+            f.write(f"vn {item[0]} {item[1]} {item[2]}\n")
+        for item in faces:
+            f.write(f"f {item[0]}//{item[0]} {item[1]}//{item[1]} "
+                    f"{item[2]}//{item[2]}\n")
+        f.close()
+
+
+def reorient_image(image, invert_axes=None, orientation="saggital"):
+    """[Reorients the image to the coordinate space of the atlas]
+
+    Arguments:
+        image_path {[str]} -- [Path of image file]
+        threshold {[float]} -- [Image threshold to define the surface] (default: {0})
+        invert_axes {[tuple]} -- [Tuple of axes to invert (if not in the same orientation as the atlas] (default: {None})
+    """
+    # TODO: move this to brainio
+    if invert_axes is not None:
+        for axis in invert_axes:
+            image = np.flip(image, axis=axis)
+
+    if orientation is not "saggital":
+        if orientation is "coronal":
+            transposition = (2, 1, 0)
+        elif orientation is "horizontal":
+            transposition = (1, 2, 0)
+
+        image = np.transpose(image, transposition)
+    return image
+
+
+def image_to_surface(image_path, obj_file_path, voxel_size=1.0,
+                     threshold=0, invert_axes=None, orientation="saggital"):
+    """[Saves the surface of an image as an .obj file]
+
+    Arguments:
+        image_path {[str]} -- [Path of image file]
+        output_file {[obj_file_path]} -- [File to write to]
+        voxel_size {[float]} -- [Voxel size of the image (in um). Only isotropic voxels supported currently] (default: {1})
+        threshold {[float]} -- [Image threshold to define the surface] (default: {0})
+        invert_axes {[tuple]} -- [Tuple of axes to invert (if not in the same orientation as the atlas] (default: {None})
+    """
+
+    image = brainio.load_any(image_path)
+
+    image = reorient_image(image, invert_axes=invert_axes,
+                           orientation=orientation)
+    verts, faces, normals, values = \
+        measure.marching_cubes_lewiner(image, threshold)
+
+    # Scale to atlas spacing
+    if voxel_size is not 1:
+        verts = verts * voxel_size
+
+    faces = faces + 1
+
+    marching_cubes_to_obj((verts, faces, normals, values), obj_file_path)

--- a/BrainRender/Utils/paths_manager.py
+++ b/BrainRender/Utils/paths_manager.py
@@ -44,4 +44,4 @@ class Paths:
         for fld in list(self.folders.values()):
             if not os.path.isdir(fld):
                 print("Creating folder at: {}".format(fld))
-                os.mkdir(fld)
+                os.makedirs(fld)

--- a/BrainRender/Utils/paths_manager.py
+++ b/BrainRender/Utils/paths_manager.py
@@ -3,7 +3,7 @@ import os
 from .data_io import load_yaml
 
 class Paths:
-    def __init__(self, paths_file = None):
+    def __init__(self, paths_file=None):
         """[Parses a YAML file to get data folders paths]
         
         Keyword Arguments:

--- a/BrainRender/scene.py
+++ b/BrainRender/scene.py
@@ -36,7 +36,7 @@ class Scene(ABA):  # subclass brain render to have acces to structure trees
     video_camera_params = {"viewup": [0, -1, 0]}
 
     def __init__(self, brain_regions=None, regions_aba_color=False, 
-                    neurons=None, tracts=None, add_root=None, verbose=True, jupyter=False, display_inset=None, path_file=None):
+                    neurons=None, tracts=None, add_root=None, verbose=True, jupyter=False, display_inset=None, paths_file=None):
         """[Creates and manages a Plotter instance]
         
         Keyword Arguments:
@@ -49,7 +49,7 @@ class Scene(ABA):  # subclass brain render to have acces to structure trees
             add_root {[bool]} -- [if true add semi transparent brain shape to scene. If None the default setting is used] (default: {None})
             path_file {[str]} -- [Path to a YAML file specifying paths to data folders, to replace default paths] (default: {None})
         """
-        ABA.__init__(self, path_file=path_file)
+        ABA.__init__(self, paths_file=paths_file)
 
         self.verbose = verbose
         self.regions_aba_color = regions_aba_color

--- a/Installation/dependencies.txt
+++ b/Installation/dependencies.txt
@@ -7,4 +7,4 @@ allensdk
 k3d
 tqdm
 json
-multiprocessing
+pyyaml

--- a/README.md
+++ b/README.md
@@ -23,28 +23,28 @@ To create the render BrainRender relies on [vtkplotter](https://vtkplotter.embl.
 Check the [user guide](UserGuide.md) and the [examples](Examples) for more information
 
 ## Mouse Light neurons morphology rendering
-<img src="Screenshots/neuron.png" width="600" height="350">
+<img src="Output/Screenshots/neuron.png" width="600" height="350">
 Motor cortex piramidal neuron reconstruction from Mouse Light.
 
 ## Rendering of different sets of brainstem projecting neurons using MultiScene
-<img src="Screenshots/multiscene_1.png" width="600" height="350">
+<img src="Output/Screenshots/multiscene_1.png" width="600" height="350">
 Sets of neurons projecting to the brainstem, sorted by brain region.
 
 ## Allen mouse connectome projection data rendering
 ### Tractography
-<img src="Screenshots/tractography.png" width="600" height="350">
+<img src="Output/Screenshots/tractography.png" width="600" height="350">
 Projections to the Zona Incerta, colored by projection area.
 
 ### Streamlines
-<img src="Screenshots/streamlines2.png" width="600" height="350">
+<img src="Output/Screenshots/streamlines2.png" width="600" height="350">
 Efferents from the VAL nucleus of the thalamus.
 
 ### Streamlines
-<img src="Screenshots/streamlines2.png" width="600" height="350">
+<img src="Output/Screenshots/streamlines2.png" width="600" height="350">
 Efferents from the VAL nucleus of the thalamus.
 
 ### Ratbrain
-<img src="Screenshots/ratbrain2.png" width="600" height="350">
+<img src="Output/Screenshots/ratbrain2.png" width="600" height="350">
 The rat and mouse brains side by side. 
 
 

--- a/README.md
+++ b/README.md
@@ -39,10 +39,6 @@ Projections to the Zona Incerta, colored by projection area.
 <img src="Output/Screenshots/streamlines2.png" width="600" height="350">
 Efferents from the VAL nucleus of the thalamus.
 
-### Streamlines
-<img src="Output/Screenshots/streamlines2.png" width="600" height="350">
-Efferents from the VAL nucleus of the thalamus.
-
 ### Ratbrain
 <img src="Output/Screenshots/ratbrain2.png" width="600" height="350">
 The rat and mouse brains side by side. 

--- a/UserGuide.md
+++ b/UserGuide.md
@@ -24,6 +24,20 @@ If you are using anaconda you can simply crate an environment using the installa
 ```conda env create --name NAME --file path_to_your_repo/Installation/environment.yml```
 
 
+Alternatively, it should now be possible to install BrainRender as a package, thank's to [Adam Tyson](https://github.com/adamltyson)'s contribution:
+
+***
+Tested on Linux (Ubuntu 18.04) and Windows (10 Enterprise LTSC) with Python 3.6.9.
+
+Installation seems to work fine via:
+`conda create --name brainrender python=3.6`
+`conda activate brainrender`
+`pip install BrainRender`
+
+BrainRender should be installable with:
+`pip install git+https://github.com/BrancoLab/BrainRender`
+***
+
 ### Folder structure
 BrainRender needs to save and access data from your machine. 
 For this reason you will need to specify the folder in which each type of data will be stored [for more details please see [settings.py](BrainRender/settings.py)]. 

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,27 @@
+from setuptools import setup, find_namespace_packages
+
+requirements = [
+    "numpy",
+    "pandas",
+    "vtkplotter",
+    "vtk",
+    "jupyter",
+    "allensdk",
+    "k3d",
+    "tqdm",
+]
+
+setup(
+    name="BrainRender",
+    version="0.1.0",
+    description="Python scripts to use Allen Brain Map data for analysis "
+                "and rendering",
+    install_requires=requirements,
+    python_requires=">=3.6",
+    packages=find_namespace_packages(exclude=(
+        "Installation", "Meshes", "Metadata", "Screenshots")),
+    include_package_data=True,
+    url="https://github.com/BrancoLab/BrainRender",
+    author="Federico Claudi",
+    zip_safe=False,
+)

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ requirements = [
     "allensdk",
     "k3d",
     "tqdm",
+    "pyyaml"
 ]
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,9 @@ requirements = [
     "allensdk",
     "k3d",
     "tqdm",
-    "pyyaml"
+    "pyyaml",
+    "scikit-image",
+    "brainio",
 ]
 
 setup(


### PR DESCRIPTION
**Work in progress**

A new method of `BrainRender.scene.add_image` is added. This allows you to render a custom region, defined by a 3D image. Potentially useful for visualising injection sites, lesions etc.

The image is loaded, and then a surface is extracted based on a threshold (default is 0 for binary images). This surface is saved as an `.obj` file, and loaded via `scene.add_from_file`.

As the coordinate space of the rendering is unlikely to be the same as your image, options are included to scale, rotate and flip the image to the correct coordinate space, e.g.:

```bash
from BrainRender.scene import Scene

scene = Scene(jupyter=True)
scene.add_image(/path/to/image.nii, voxel_size=10, orientation="horizontal", invert_axes=(1,2))
scene.render()
```

`brainio` (my package if there any issues) is used to load images, and so the following formats should be supported (although only tested with .nii):
* .nii (and .nii.gz)
* .nrrd
* 3D multipage tiff
* Directory or list of 2D tiffs

This method can be slow if the image is large. The image -> vertices conversion, and the vertices rendering should be split up, and allow people to keep a directory of "their" regions.

This is all based on the ARA. I propose that we keep that coordinate framework for all potential applications, and transform others if required.

In addition:
* `.gitignore` updated
* reference to `paths` standardised, and bug fix to ensure it's passed to `paths_manager.Paths`
* `paths_manager.Paths` updated to create intermediate directories
* Dependencies updated