### PR TITLE
Render objects from image at lower resolution by default.

### DIFF
--- a/BrainRender/Utils/image.py
+++ b/BrainRender/Utils/image.py
@@ -47,7 +47,8 @@ def reorient_image(image, invert_axes=None, orientation="saggital"):
 
 
 def image_to_surface(image_path, obj_file_path, voxel_size=1.0,
-                     threshold=0, invert_axes=None, orientation="saggital"):
+                     threshold=0, invert_axes=None, orientation="saggital",
+                     step_size=1):
     """[Saves the surface of an image as an .obj file]
 
     Arguments:
@@ -63,7 +64,7 @@ def image_to_surface(image_path, obj_file_path, voxel_size=1.0,
     image = reorient_image(image, invert_axes=invert_axes,
                            orientation=orientation)
     verts, faces, normals, values = \
-        measure.marching_cubes_lewiner(image, threshold)
+        measure.marching_cubes_lewiner(image, threshold, step_size=step_size)
 
     # Scale to atlas spacing
     if voxel_size is not 1:

--- a/BrainRender/scene.py
+++ b/BrainRender/scene.py
@@ -683,7 +683,8 @@ class Scene(ABA):  # subclass brain render to have acces to structure trees
 
     def add_image(self, image_file_path, color=None, alpha=None,
                   obj_file_path=None, voxel_size=1, orientation="saggital",
-                  invert_axes=None, extension=".obj", delete_obj_file=False):
+                  invert_axes=None, extension=".obj", step_size=2,
+                  delete_obj_file=False):
 
         if color is None:
             color = [random.uniform(0, 1),
@@ -698,7 +699,8 @@ class Scene(ABA):  # subclass brain render to have acces to structure trees
 
         # TODO: avoid temporary file & pass vertices directly
         image_to_surface(image_file_path, obj_file_path, voxel_size=voxel_size,
-                         orientation=orientation, invert_axes=invert_axes)
+                         orientation=orientation, invert_axes=invert_axes,
+                         step_size=step_size)
 
         self.add_from_file(obj_file_path, c=color, alpha=alpha)
 


### PR DESCRIPTION
Speeds up the rendering of large images by a factor of about 3. Will have less of an effect on small images (mostly I/O bound).