### PR TITLE
Load cells from file.

### DIFF
--- a/BrainRender/scene.py
+++ b/BrainRender/scene.py
@@ -679,9 +679,8 @@ class Scene(ABA):  # subclass brain render to have acces to structure trees
     def add_cells_from_file(self, filepath, hdf_key=None, color="red",
                             radius=25, res=3):
 
-        supported_formats = HDF_SUFFIXES
-        if hdf_key is None:
-            hdf_key = DEFAULT_HDF_KEY
+        csv_suffix = ".csv"
+        supported_formats = HDF_SUFFIXES + [csv_suffix]
 
         filepath = Path(filepath)
         if not filepath.exists():
@@ -689,6 +688,8 @@ class Scene(ABA):  # subclass brain render to have acces to structure trees
 
         if filepath.suffix in supported_formats:
             if filepath.suffix in HDF_SUFFIXES:
+                if hdf_key is None:
+                    hdf_key = DEFAULT_HDF_KEY
                 try:
                     cells = pd.read_hdf(filepath, key=hdf_key)
                 except TypeError:
@@ -702,6 +703,8 @@ class Scene(ABA):  # subclass brain render to have acces to structure trees
                         raise ValueError(
                             f"The key: {hdf_key} cannot be found in the hdf "
                             f"file. Please check the correct identifer.")
+            elif filepath.suffix == csv_suffix:
+                cells = pd.read_csv(filepath)
 
             self.add_cells(cells, color=color, radius=radius, res=res)
 

--- a/BrainRender/scene.py
+++ b/BrainRender/scene.py
@@ -675,10 +675,10 @@ class Scene(ABA):  # subclass brain render to have acces to structure trees
     def add_sphere_at_point(self, pos=[0, 0, 0], radius=100, color="black", alpha=1):
         self.actors['others'].append(Sphere(pos=pos, r=radius, c=color, alpha=alpha))
 
-    def add_cells(self, coords, color="red", radius=25): # WIP 
+    def add_cells(self, coords, color="red", radius=25, res=3): # WIP
         if isinstance(coords, pd.DataFrame):
             coords = [[x, y, z] for x,y,z in zip(coords['x'].values, coords['y'].values, coords['z'].values)]
-        spheres = Spheres(coords, c=color, r=radius, res=3)
+        spheres = Spheres(coords, c=color, r=radius, res=res)
         self.actors['others'].append(spheres)
 
     def add_image(self, image_file_path, color=None, alpha=None,

--- a/BrainRender/variables.py
+++ b/BrainRender/variables.py
@@ -61,6 +61,11 @@ settings.screeshotScale = 1  # Improves resolution of saved screenshots
 NEURONS_FILE = "Examples/example_files/one_neuron.json"
 VERBOSE = True                  # if True print useful messages during use
 
+""" ------------------------------------------------------------------------------------------------------------------------------------------- """
+        # SUPPORTED_FILE FORMATS
+""" ------------------------------------------------------------------------------------------------------------------------------------------- """
+HDF_SUFFIXES = [".h5", ".hdf", ".hdf5", ".he5"]
+DEFAULT_HDF_KEY = "df"
 
 
 


### PR DESCRIPTION
Allows loading of hdf5 or csv files containing cell (or other point objects) positions, with column headings including `x`, `y`, and `z`.

Cell positions must be in the same coordinate space as the root image.