### PR TITLE
remove gzip from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,6 @@ requirements = [
     "pyyaml",
     "scikit-image",
     "brainio",
-    "gzip",
 ]
 
 setup(


### PR DESCRIPTION
Gzip is in the standard library (and not on pypi). Removing it from `setup.py` allows for pip installation.