### PR TITLE
use os library to get path parts

### DIFF
--- a/BrainRender/Utils/data_io.py
+++ b/BrainRender/Utils/data_io.py
@@ -35,9 +35,6 @@ def listdir(fld):
 
 	return [os.path.join(fld, f) for f in os.listdir(fld)]
 
-def strip_path(path):
-    return path.strip('/').strip('\\').split('/')[-1].split('\\')
-
 def load_json(filepath):
 	if not os.path.isfile(filepath) or not ".json" in filepath.lower(): raise ValueError("unrecognized file path: {}".format(filepath))
 	with open(filepath) as f:

--- a/BrainRender/Utils/videomaker.py
+++ b/BrainRender/Utils/videomaker.py
@@ -5,8 +5,6 @@ from vtkplotter import *
 import inspect
 import os
 
-from BrainRender.Utils.data_io import strip_path
-
 class VideoMaker:
     def __init__(self, scene, **kwargs):
         """[This class takes care of creating videos with animating scenes.]
@@ -68,8 +66,8 @@ class VideoMaker:
         self._setup_videos()
 
         # open a video file and force it to last 3 seconds in total
-        stripped = strip_path(self.savefile)
-        folder, name = os.path.join(*stripped[:-1]), stripped[-1]
+        folder = os.path.dirname(self.savefile)
+        name = os.path.basename(self.savefile)
         curdir = os.getcwd()
         os.chdir(folder)
         video = Video(name=name, duration=self.duration, fps=self.fps)


### PR DESCRIPTION
The strip_path function would error on my system with:

`TypeError: join() missing 1 required positional argument: 'a'`

The os library has functions with do the desired functionality, so I've used this in place and it works well.