### PR TITLE
remove jupyter and k3d from dependencies

### DIFF
--- a/Installation/dependencies.txt
+++ b/Installation/dependencies.txt
@@ -2,9 +2,7 @@ numpy
 pandas
 vtkplotter
 vtk
-jupyter
 allensdk
-k3d
 tqdm
 pyyaml
 brainio

--- a/setup.py
+++ b/setup.py
@@ -5,9 +5,7 @@ requirements = [
     "pandas",
     "vtkplotter",
     "vtk",
-    "jupyter",
     "allensdk",
-    "k3d",
     "tqdm",
     "pyyaml",
     "scikit-image",
@@ -20,6 +18,7 @@ setup(
     description="Python scripts to use Allen Brain Map data for analysis "
                 "and rendering",
     install_requires=requirements,
+    extras_require={"nb": ["jupyter", "k3d" ]},
     python_requires=">=3.6",
     packages=find_namespace_packages(exclude=(
         "Installation", "Meshes", "Metadata", "Screenshots")),


### PR DESCRIPTION
These two packages are not required to use the BrainRender package so I suggest removing them from the dependencies list.

I think if users want to use jupyter notebooks for BrainRender then it's a separate setup that they have already configured on their system.